### PR TITLE
remove start so that the application doesn't hang

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -41,8 +41,7 @@ jobs:
       - name: Build site
         run: |
           npm run build
-          npm start
-
+          
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
 


### PR DESCRIPTION


Attention: Next.js now collects completely anonymous telemetry regarding usage.
This information is used to shape Next.js' roadmap and prioritize features.
You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:
https://nextjs.org/telemetry

  ▲ Next.js [1](https://github.com/tazzledazzle/tazzledazzle.github.io/actions/runs/15432325522/job/43432298573#step:6:1)4.2.29

   Creating an optimized production build ...
 ✓ Compiled successfully
   Linting and checking validity of types ...
   Collecting page data ...
   Generating static pages (0/4) ...
   Generating static pages (1/4) 
   Generating static pages (2/4) 
   Generating static pages (3/4) 
 ✓ Generating static pages (4/4)
   Finalizing page optimization ...
   Collecting build traces ...

Route (app)                              Size     First Load JS
┌ ○ /                                    5.34 kB         101 kB
└ ○ /_not-found                          8[7](https://github.com/tazzledazzle/tazzledazzle.github.io/actions/runs/15432325522/job/43432298573#step:6:8)3 B          [8](https://github.com/tazzledazzle/tazzledazzle.github.io/actions/runs/15432325522/job/43432298573#step:6:9)8.1 kB
+ First Load JS shared by all            87.2 kB
  ├ chunks/117-ba42e08[9](https://github.com/tazzledazzle/tazzledazzle.github.io/actions/runs/15432325522/job/43432298573#step:6:10)470b2474.js       31.7 kB
  ├ chunks/fd9d[10](https://github.com/tazzledazzle/tazzledazzle.github.io/actions/runs/15432325522/job/43432298573#step:6:11)56-3eee857bde8f3b06.js  53.6 kB
  └ other shared chunks (total)          1.89 kB


○  (Static)  prerendered as static content


> myblog@1.0.0 start
> npx serve@latest out

npm warn exec The following package was not found and will be installed: serve@14.2.4
 INFO  Accepting connections at http://localhost:3000
Error: The operation was canceled.