### PR TITLE
Add Jest tests for Next.js app

### DIFF
--- a/__tests__/blog.test.tsx
+++ b/__tests__/blog.test.tsx
@@ -1,0 +1,42 @@
+import { fetchPost, generateStaticParams, default as PostPage } from '../app/blog/[id]/page';
+import { render, screen } from '@testing-library/react';
+import fs from 'fs';
+
+jest.mock('fs');
+const mockedRead = fs.readFileSync as jest.Mock;
+
+describe('blog page utilities', () => {
+  beforeEach(() => {
+    mockedRead.mockReset();
+  });
+
+  test('generateStaticParams returns ids', () => {
+    expect(generateStaticParams()).toEqual([
+      { id: '1' },
+      { id: '2' },
+      { id: '3' },
+    ]);
+  });
+
+  test('fetchPost parses markdown', async () => {
+    mockedRead.mockReturnValue('---\ntitle: Test\n---\ncontent');
+    const result = await fetchPost('1');
+    expect(result.title).toBe('Test');
+    expect(result.content).toContain('<p>content');
+  });
+
+  test('fetchPost throws on error', async () => {
+    mockedRead.mockImplementation(() => { throw new Error('fail'); });
+    await expect(fetchPost('missing')).rejects.toThrow('fail');
+  });
+});
+
+describe('PostPage component', () => {
+  test('renders fetched post', async () => {
+    mockedRead.mockReturnValue('---\ntitle: Hello\n---\nworld');
+    const element = await PostPage({ params: { id: '1' } });
+    render(element);
+    expect(screen.getByRole('heading', { name: 'Hello' })).toBeInTheDocument();
+    expect(screen.getByText('world')).toBeInTheDocument();
+  });
+});

--- a/__tests__/blog.test.tsx
+++ b/__tests__/blog.test.tsx
@@ -4,13 +4,16 @@ import fs from 'fs';
 
 jest.mock('fs');
 const mockedRead = fs.readFileSync as jest.Mock;
+const mockedReaddirSync = fs.readdirSync as jest.Mock;
 
 describe('blog page utilities', () => {
   beforeEach(() => {
     mockedRead.mockReset();
+    mockedReaddirSync.mockReset();
   });
 
   test('generateStaticParams returns ids', () => {
+    mockedReaddirSync.mockReturnValue(['1.md', '2.md', '3.md']);
     expect(generateStaticParams()).toEqual([
       { id: '1' },
       { id: '2' },

--- a/__tests__/footer.test.tsx
+++ b/__tests__/footer.test.tsx
@@ -1,0 +1,10 @@
+import Footer from '../app/components/Footer';
+import { render, screen } from '@testing-library/react';
+
+describe('Footer component', () => {
+  test('displays current year', () => {
+    render(<Footer />);
+    const year = new Date().getFullYear().toString();
+    expect(screen.getByText((content) => content.includes(year))).toBeInTheDocument();
+  });
+});

--- a/__tests__/navigation.test.tsx
+++ b/__tests__/navigation.test.tsx
@@ -1,0 +1,13 @@
+import Navigation from '../app/components/Navigation';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+describe('Navigation component', () => {
+  test('toggles mobile menu', () => {
+    const { getByRole, getByTestId } = render(<Navigation />);
+    const button = getByRole('button');
+    const menu = getByTestId('mobile-menu');
+    expect(menu.classList.contains('hidden')).toBe(true);
+    fireEvent.click(button);
+    expect(menu.classList.contains('block')).toBe(true);
+  });
+});

--- a/__tests__/pages.test.tsx
+++ b/__tests__/pages.test.tsx
@@ -1,0 +1,17 @@
+import Home from '../app/page';
+import ContactPage from '../app/contact/page';
+import { render, screen } from '@testing-library/react';
+
+describe('static pages', () => {
+  test('home renders headings', () => {
+    render(<Home />);
+    expect(screen.getByRole('heading', { name: /Terence Schumacher/ })).toBeInTheDocument();
+  });
+
+  test('contact page renders email', async () => {
+    const element = await ContactPage();
+    render(element);
+    expect(screen.getByRole('heading', { name: 'Contact Me' })).toBeInTheDocument();
+    expect(screen.getByText(/terenceschumacher@gmail.com/)).toBeInTheDocument();
+  });
+});

--- a/__tests__/projects.test.tsx
+++ b/__tests__/projects.test.tsx
@@ -1,0 +1,40 @@
+import { getProjectData, generateStaticParams, default as ProjectPage } from '../app/projects/[id]/page';
+import { render, screen } from '@testing-library/react';
+import fs from 'fs';
+
+jest.mock('fs');
+const mockedRead = fs.readFileSync as jest.Mock;
+const mockedReaddir = fs.readdirSync as jest.Mock;
+
+describe('projects utilities', () => {
+  beforeEach(() => {
+    mockedRead.mockReset();
+    mockedReaddir.mockReset();
+  });
+
+  test('generateStaticParams reads project files', () => {
+    mockedReaddir.mockReturnValue(['1.md', '2.md']);
+    expect(generateStaticParams()).toEqual([{ id: '1' }, { id: '2' }]);
+  });
+
+  test('getProjectData parses markdown', async () => {
+    mockedRead.mockReturnValue(`---\ntitle: T\ndescription: D\nimage: i.jpg\ngithub: g\nlive: l\n---\ncontent`);
+    const result = await getProjectData('1');
+    expect(result.title).toBe('T');
+    expect(result.description).toBe('D');
+    expect(result.image).toBe('i.jpg');
+    expect(result.github).toBe('g');
+    expect(result.live).toBe('l');
+    expect(result.content).toContain('<p>content');
+  });
+});
+
+describe('ProjectPage component', () => {
+  test('renders project content', async () => {
+    mockedRead.mockReturnValue(`---\ntitle: Test\n---\nhello`);
+    const element = await ProjectPage({ params: { id: '1' } });
+    render(element);
+    expect(screen.getByRole('heading', { name: 'Test' })).toBeInTheDocument();
+    expect(screen.getByText('hello')).toBeInTheDocument();
+  });
+});

--- a/app/blog/[id]/page.tsx
+++ b/app/blog/[id]/page.tsx
@@ -13,7 +13,7 @@ export function generateStaticParams() {
 ];
 }
 
-async function fetchPost(id: string) {
+export async function fetchPost(id: string) {
   const filePath = path.join(process.cwd(), '_posts', `${id}.md`);
   var fileContents = '';
   try {

--- a/app/components/Navigation.tsx
+++ b/app/components/Navigation.tsx
@@ -58,10 +58,13 @@ const Navigation = () => {
         </div>
 
         {/* Mobile menu */}
-        <div className={clsx(
-          'md:hidden',
-          isOpen ? 'block' : 'hidden'
-        )}>
+        <div
+          data-testid="mobile-menu"
+          className={clsx(
+            'md:hidden',
+            isOpen ? 'block' : 'hidden'
+          )}
+        >
           <div className="pt-2 pb-3 space-y-1">
             {links.map(({ href, label }) => (
               <Link

--- a/app/projects/[id]/page.tsx
+++ b/app/projects/[id]/page.tsx
@@ -7,7 +7,7 @@ import matter from 'gray-matter';
 import { remark } from 'remark';
 import html from 'remark-html';
 
-async function getProjectData(id: string) {
+export async function getProjectData(id: string) {
   const filePath = path.join(process.cwd(), 'app', '_projects', `${id}.md`);
   const fileContents = fs.readFileSync(filePath, 'utf8');
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['@testing-library/jest-dom/extend-expect'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/$1'
+  },
+  testPathIgnorePatterns: ['/node_modules/', '/.next/']
+};

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "deploy": "gh-pages -d out -u \"github-actions[bot] <github-actions[bot]@users.noreply.github.com>\"",
     "export": "next export",
     "lint": "next lint",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "test": "jest"
   },
   "dependencies": {
     "@heroicons/react": "^2.1.1",
@@ -32,7 +33,13 @@
     "@tailwindcss/typography": "^0.5.10",
     "@types/node": "^20.11.0",
     "@types/react": "^18.2.0",
+    "@types/jest": "^29.5.11",
     "autoprefixer": "^10.4.17",
+    "jest": "^29.6.3",
+    "ts-jest": "^29.1.1",
+    "@testing-library/react": "^14.1.2",
+    "@testing-library/jest-dom": "^6.3.0",
+    "jest-environment-jsdom": "^29.6.3",
     "postcss": "^8.4.35",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.3.3"


### PR DESCRIPTION
## Summary
- configure Jest with ts-jest and RTL
- export helper functions for testing
- add data-testid hook for navigation
- write tests for pages, components and utilities

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840801e6c00832d89ebd7b1373f2d44